### PR TITLE
Fixed sorting of mission required DLCs causing them to be unset

### DIFF
--- a/src/api/controllers/v1/mission.ts
+++ b/src/api/controllers/v1/mission.ts
@@ -412,8 +412,10 @@ export function updateMission(request: Hapi.Request, reply: Hapi.ReplyWithContin
             notifyUpdate = true;
         }
 
-        // Ensure list of required DLCs is always sorted/displayed the same way
-        payload.requiredDLCs = _.sortBy(payload.requiredDLCs);
+        if (!_.isEmpty(payload.requiredDLCs)) {
+            // Ensure list of required DLCs is always sorted/displayed the same way
+            payload.requiredDLCs = _.sortBy(payload.requiredDLCs);
+        }
 
         await mission.update(payload, {
             fields: [

--- a/src/shared/services/SteamService.ts
+++ b/src/shared/services/SteamService.ts
@@ -64,7 +64,7 @@ export class SteamService {
                     if (_.isNil(steamId) || steamId.length < 2) {
                         log.warn({ function: 'verifySteamLogin', result }, 'Failed to verify Steam login, claimedIdentifier was invalid');
 
-                        return reject('Failed to verify Steam login');
+                        return reject(Boom.conflict('Failed to verify Steam login'));
                     }
 
                     return resolve(steamId[1]);


### PR DESCRIPTION
Sorting a non-provided array created an empty one, thus unsetting the requried DLCs for a mission on every update